### PR TITLE
Fix social share modal error

### DIFF
--- a/src/components/scroll-hud/components/social-sharer/social-sharer.vue
+++ b/src/components/scroll-hud/components/social-sharer/social-sharer.vue
@@ -36,8 +36,9 @@
                 this.openShareModal();
             },
             openShareModal() {
-                this.$modal.open({
+                this.$buefy.modal.open({
                     parent: this,
+                    hasModalCard: true,
                     component: obSocialSharerModal
                 })
             }


### PR DESCRIPTION
This is a fix for the social share button bug that throw an error when click it and doesn't open the modal component.

Error when click on share button:
``TypeError: "this.$modal is undefined"``